### PR TITLE
Add template for project suggestions

### DIFF
--- a/template.md
+++ b/template.md
@@ -1,0 +1,13 @@
+# *Name of project*
+
+## Description
+
+*Include a link to the project Github page and possibly website. If there isn't a contributor's guide, briefly describe the main areas of development focus.*
+
+## Target Issues
+
+*Tell us what issues you want to resolve.  You can list them here, or refer to an issue label*
+
+## Representative
+
+*Would you be comfortable explaining the issues to the rest of us? If not, let us know who might be.*


### PR DESCRIPTION
This is a template for anyone who wants to suggest a project.

I'm not sure if we should have it as a markdown file, or as an issue template, or even a PR template.  Copying over the template file as it is now might be a bit tedious.